### PR TITLE
Initial support for authentication using Google Service Accounts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,20 @@
 var init = async function() {
   var server = require("./server");
   var readJSON = require("./lib/readJSON");
+  var getAuthType = require("./lib/googleAuth").getAuthType;
   var configuration = require("./lib/configuration");
 
   var config = await configuration.load("./config.json");
 
-  var environmentWhitelist = [
-    "GOOGLE_OAUTH_CLIENT_ID",
-    "GOOGLE_OAUTH_CONSUMER_SECRET"
-  ];
+  var environmentWhitelist = [];
+
+  switch (getAuthType()) {
+    case "service_account":
+      environmentWhitelist.push("GOOGLE_APPLICATION_CREDENTIALS");
+      break;
+    default:
+      environmentWhitelist.push("GOOGLE_OAUTH_CLIENT_ID", "GOOGLE_OAUTH_CONSUMER_SECRET");
+  }
 
   if (!config.deployTo || config.deployTo == "s3") {
     environmentWhitelist.push("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY");

--- a/lib/googleAuth.js
+++ b/lib/googleAuth.js
@@ -1,52 +1,18 @@
-var fs = require("fs").promises;
-var os = require("os");
-var path = require("path");
-
-var { google } = require("googleapis");
-
-var clientID = process.env.GOOGLE_OAUTH_CLIENT_ID;
-var secret = process.env.GOOGLE_OAUTH_CONSUMER_SECRET;
-
-var tokenPath = path.join(os.homedir(), ".google_oauth_token");
-
-var getClient = async function(redirect = "http://localhost:8000/authenticate/") {
-  var auth = new google.auth.OAuth2(clientID, secret, redirect);
-  try {
-    var tokens = await loadTokenFile();
-    auth.setCredentials(tokens);
-  } catch (err) {
-    // token file won't exist on first login
+var getAuthType = function() {
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return "service_account";
+  } else {
+    return "oauth";
   }
+}
 
-  auth.on("tokens", updateTokenFile);
-
-  return auth;
-};
-
-var scopes = ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"];
-
-var loadTokenFile = async function() {
-  var tokens = await fs.readFile(tokenPath, "utf-8");
-  tokens = JSON.parse(tokens);
-  if (!tokens.access_token && !tokens.refresh_token) throw "Token file contains no actual tokens";
-  return tokens;
-};
-
-var updateTokenFile = async function(update) {
-  try {
-    var tokens = await loadTokenFile();
-  } catch (err) {
-    var tokens = {};
+var getAuthModule = function() {
+  switch (getAuthType()) {
+    case "service_account":
+      return require("./googleServiceAuth");
+    default:
+      return require("./googleOAuth");
   }
-  Object.assign(tokens, update);
-  if (!tokens.refresh_token) {
-    console.log("WARNING: No refresh_token in your Google OAuth credentials. You may have trouble staying signed in.");
-    console.log(
-      "If problems persist, visit https://myaccount.google.com/permissions and revoke permissions for this app, then reauthorize locally."
-    );
-  }
-  await fs.writeFile(tokenPath, JSON.stringify(tokens, null, 2));
-  return tokens;
-};
+}
 
-module.exports = { getClient, scopes, tokenPath, loadTokenFile, updateTokenFile };
+module.exports = { getAuthType, getAuthModule }

--- a/lib/googleOAuth.js
+++ b/lib/googleOAuth.js
@@ -1,0 +1,52 @@
+var fs = require("fs").promises;
+var os = require("os");
+var path = require("path");
+
+var { google } = require("googleapis");
+
+var clientID = process.env.GOOGLE_OAUTH_CLIENT_ID;
+var secret = process.env.GOOGLE_OAUTH_CONSUMER_SECRET;
+
+var tokenPath = path.join(os.homedir(), ".google_oauth_token");
+
+var getClient = async function(redirect = "http://localhost:8000/authenticate/") {
+  var auth = new google.auth.OAuth2(clientID, secret, redirect);
+  try {
+    var tokens = await loadTokenFile();
+    auth.setCredentials(tokens);
+  } catch (err) {
+    // token file won't exist on first login
+  }
+
+  auth.on("tokens", updateTokenFile);
+
+  return auth;
+};
+
+var scopes = ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"];
+
+var loadTokenFile = async function() {
+  var tokens = await fs.readFile(tokenPath, "utf-8");
+  tokens = JSON.parse(tokens);
+  if (!tokens.access_token && !tokens.refresh_token) throw "Token file contains no actual tokens";
+  return tokens;
+};
+
+var updateTokenFile = async function(update) {
+  try {
+    var tokens = await loadTokenFile();
+  } catch (err) {
+    var tokens = {};
+  }
+  Object.assign(tokens, update);
+  if (!tokens.refresh_token) {
+    console.log("WARNING: No refresh_token in your Google OAuth credentials. You may have trouble staying signed in.");
+    console.log(
+      "If problems persist, visit https://myaccount.google.com/permissions and revoke permissions for this app, then reauthorize locally."
+    );
+  }
+  await fs.writeFile(tokenPath, JSON.stringify(tokens, null, 2));
+  return tokens;
+};
+
+module.exports = { getClient, scopes, tokenPath, loadTokenFile, updateTokenFile };

--- a/lib/googleServiceAuth.js
+++ b/lib/googleServiceAuth.js
@@ -1,0 +1,13 @@
+var { google } = require("googleapis");
+
+var scopes = ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"];
+
+var getClient = async function() {
+  const auth = await google.auth.getClient({
+    scopes: scopes
+  });
+
+  return auth;
+};
+
+module.exports = { getClient, scopes }

--- a/lib/sheetOps.js
+++ b/lib/sheetOps.js
@@ -1,7 +1,7 @@
 var { google } = require("googleapis");
 var { promisify } = require("util");
 
-var { getClient } = require("./googleAuth");
+var { getClient } = require("./googleAuth").getAuthModule();
 
 var camelCase = function(str) {
   return str.replace(/[^\w]+(\w)/g, function(all, match) {

--- a/readme.rst
+++ b/readme.rst
@@ -43,6 +43,13 @@ We recognize that environment variables are not perfectly secure (since installe
 
 The Google OAuth variables should match the client ID and secret for an API app that can access your account. `This post <http://blog.apps.npr.org/2015/03/02/app-template-oauth.html>`_ has details on setting that up.
 
+Alternatively, `service account authentication <https://developers.google.com/identity/protocols/OAuth2ServiceAccount>`_ is also supported. To create a service account and JSON key file, visit your project's `GCP web console <https://console.cloud.google.com/iam-admin/serviceaccounts>`_ to get started.
+
+After creating the service account:
+
+1. Grant write access on your Drive folder (``driveFolder`` in ``config.json``) to the service account email address.
+2. Set GOOGLE_APPLICATION_CREDENTIALS to the file path of the JSON file containing your credentials.
+
 If you're deploying to S3, which is the default for the rig, you'll also need to set:
 
 * AWS_ACCESS_KEY_ID

--- a/server/handlers/googleOAuth.js
+++ b/server/handlers/googleOAuth.js
@@ -4,7 +4,7 @@ var { URL } = require("url");
 var authorize = async function(request, response) {
   var app = request.app;
 
-  var { getClient, scopes } = app.get("google").auth;
+  var { getClient, scopes } = require("../../lib/googleOAuth");
 
   var host = request.hostname;
   var port = app.get("port");
@@ -26,7 +26,7 @@ var authorize = async function(request, response) {
 var authenticate = async function(request, response) {
   var app = request.app;
   var server = app.get("server");
-  var { getClient, updateTokenFile } = app.get("google").auth;
+  var { getClient, updateTokenFile } = require("../../lib/googleOAuth");
 
   var client = await getClient();
 

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ var bodyparser = require("body-parser");
 var express = require("express");
 var fs = require("fs").promises;
 var path = require("path");
+var getAuthType = require("../lib/googleAuth").getAuthType;
 
 var app = express();
 
@@ -40,8 +41,10 @@ module.exports = async function(config) {
   app.post("/graphic/:original/duplicate", require("./handlers/duplicateGraphic"));
 
   // Google integration
-  app.get("/authorize", require("./handlers/googleAuth").authorize);
-  app.get("/authenticate", require("./handlers/googleAuth").authenticate);
+  if (getAuthType() == "oauth") {
+    app.get("/authorize", require("./handlers/googleOAuth").authorize);
+    app.get("/authenticate", require("./handlers/googleOAuth").authenticate);
+  }
   app.post("/graphic/:slug/refresh-sheet", require("./handlers/evictSheet"));
 
   // catch-all for static assets

--- a/server/services/google.js
+++ b/server/services/google.js
@@ -21,7 +21,7 @@ module.exports = function(app) {
         return found;
       }
     },
-    auth: require("../../lib/googleAuth")
+    auth: require("../../lib/googleAuth").getAuthModule()
   };
 
   app.set("google", google);


### PR DESCRIPTION
A few notes on this implementation:

- Auth code has been split into separate modules for each auth type (currently OAuth and service accounts).
- A new function, `getAuthType()`, is used to determine which auth type is in use. OAuth is used by default, and service accounts are used if GOOGLE_APPLICATION_CREDENTIALS is set.
- Another new function, `getAuthModule()` returns the auth module currently in use.

GOOGLE_APPLICATION_CREDENTIALS is used directly by Google's auth libraries, so outside of creating the auth client, no additional handlers or logic are required.